### PR TITLE
Migrate to activity contracts

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.10" />
+    <option name="version" value="1.9.20" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CMakeSettings">
     <configurations>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ to simplify in-app update flow.
 -   Flexible updates are non-intrusive for app users with [UpdateFlowBreaker](#non-intrusive-flexible-updates-with-updateflowbreaker).
     
 ## Basics
-Refer to [original documentation](https://developer.android.com/guide/app-bundle/in-app-updates) to understand 
+Refer to [original documentation](https://developer.android.com/guide/playcore/in-app-updates) to understand 
 the basics of in-app update. This library consists of two counterparts:
 -   [AppUpdateWrapper](appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/AppUpdateWrapper.kt) is a presenter 
     (or presentation model to some extent) that is responsible for carrying out the `IMMEDIATE` or `FLEXIBLE` update 
@@ -94,7 +94,7 @@ class TestActivity : AppCompatActivity(), AppUpdateView {
     /********************************/
 
     // AppUpdateManager needs your activity to start dialogs
-    override val activity: Activity get() = this
+    override val resultContractRegistry: ActivityResultRegistry = this.activityResultRegistry
 
     // Called when flow starts
     override fun updateChecking() {
@@ -142,13 +142,13 @@ dependencies {
 application and `AppUpdateWrapper`. You may directly extend it in your hosting `Activity` or delegate it to some 
 fragment. Here are the methods you may implement:
 
-#### activity (mandatory)
+#### resultContractRegistry (mandatory)
 ```kotlin 
-val activity: Activity
+val resultContractRegistry: ActivityResultRegistry
 ```
- `AppUpdateManager` launches activities on behalf of your application. Implement this value to pass the activity that 
-will handle the `onActivityResult` and pass data to `AppUpdateWrapper.checkActivityResult`. Refer to method 
-[documentation](#checkactivityresult) to get the details.
+ `AppUpdateManager` launches activities on behalf of your application. Implement this value to pass the activity 
+result registry that will handle the `onActivityResult`. Typically you pass your activity  `activityResultRegistry`
+there.
 
 #### updateReady (mandatory)
 ```kotlin
@@ -176,7 +176,7 @@ Called by presenter when update flow starts. UI may display a spinner of some ki
 ```kotlin
 fun updateDownloadStarts()
 ```
-Called by presenter user confirms flexible update and background download begins. 
+Called when user confirms flexible update and background download begins. 
 Called in flexible flow.
 
 #### updateInstallUiVisible (optional)
@@ -211,19 +211,6 @@ The library supports both `IMMEDIATE` and `FLEXIBLE` update flows.
     details.
 
 Both flows implement the `AppUpdateWrapper` interface with the following methods to consider:
-
-#### checkActivityResult
-```kotlin
-fun checkActivityResult(requestCode: Int, resultCode: Int): Boolean
-```
-`AppUpdateManager` launches some activities from time to time: to ask for update consent, to install, etc. It does so 
-on behalf of your calling activity. Thus you must implement `onActivityResult` at your side and pass data to this method.
-If `checkActivityResult` returns true - then the result was handled. See the sample at the [top](#basics) of the article.
-In case your activity already uses the [request code](appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/constants.kt#L23) 
-used for application updates you can set a new one by setting a static var:
-```kotlin
-AppUpdateWrapper.REQUEST_CODE_UPDATE = 1111
-```
 
 #### userCanceledUpdate and userConfirmedUpdate
 ```kotlin

--- a/appupdatewrapper/build.gradle
+++ b/appupdatewrapper/build.gradle
@@ -63,11 +63,12 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    api "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     api 'androidx.core:core-ktx:1.12.0'
     api 'androidx.lifecycle:lifecycle-common:2.6.2'
-    api 'com.google.android.play:core:1.10.3'
+    api 'com.google.android.play:app-update:2.1.0'
+    api 'com.google.android.play:app-update-ktx:2.1.0'
 
     implementation 'com.jakewharton.timber:timber:5.0.1'
 
@@ -77,7 +78,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
-    testImplementation 'org.robolectric:robolectric:4.10.3'
+    testImplementation 'org.robolectric:robolectric:4.11.1'
     testImplementation 'androidx.lifecycle:lifecycle-runtime-testing:2.6.2'
 }
 

--- a/appupdatewrapper/build.gradle
+++ b/appupdatewrapper/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 
     api 'androidx.core:core-ktx:1.12.0'
     api 'androidx.lifecycle:lifecycle-common:2.6.2'
+    api 'androidx.activity:activity-ktx:1.8.1'
     api 'com.google.android.play:app-update:2.1.0'
     api 'com.google.android.play:app-update-ktx:2.1.0'
 

--- a/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/AppUpdateState.kt
+++ b/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/AppUpdateState.kt
@@ -138,7 +138,7 @@ internal abstract class AppUpdateState: AppUpdateWrapper, Tagged {
      * Checks activity result and returns `true` if result is an update result and was handled
      * Use to check update activity result in [android.app.Activity.onActivityResult]
      */
-    override fun checkActivityResult(requestCode: Int, resultCode: Int): Boolean = false
+    open fun checkActivityResult(resultCode: Int): Boolean = false
 
     /**
      * Cancels update installation

--- a/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/AppUpdateView.kt
+++ b/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/AppUpdateView.kt
@@ -15,7 +15,8 @@
 
 package com.motorro.appupdatewrapper
 
-import android.app.Activity
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultRegistry
 import androidx.lifecycle.Lifecycle.State.RESUMED
 
 /**
@@ -32,12 +33,11 @@ import androidx.lifecycle.Lifecycle.State.RESUMED
  */
 interface AppUpdateView {
     /**
-     * Returns hosting activity for update process
-     * Call [AppUpdateState.checkActivityResult] in [Activity.onActivityResult] to
-     * check update status
-     * @see AppUpdateState.checkActivityResult
+     * Returns result contract registry
+     * Wrapper will register an activity result contract to listen to update state
+     * Pass [ComponentActivity.activityResultRegistry] or other registry to it
      */
-    val activity: Activity
+    val resultContractRegistry: ActivityResultRegistry
 
     /**
      * Called when update is checking or downloading data

--- a/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/AppUpdateWrapper.kt
+++ b/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/AppUpdateWrapper.kt
@@ -16,14 +16,16 @@
 package com.motorro.appupdatewrapper
 
 import com.google.android.play.core.appupdate.AppUpdateManager
+import com.motorro.appupdatewrapper.AppUpdateWrapper.Companion.REQUEST_KEY_UPDATE
 
 /**
  * Wraps [AppUpdateManager] interaction.
  * The update wrapper is designed to be a single-use object. It carries out the workflow using host
  * [androidx.lifecycle.Lifecycle] and terminates in either [AppUpdateView.updateComplete] or
  * [AppUpdateView.updateFailed].
- * [AppUpdateManager] pops up activities-for-result from time to time. To check if the activity result belongs to update
- * flow call [checkActivityResult] function of update wrapper in your hosting activity.
+ * [AppUpdateManager] pops up activities-for-result from time to time. That is why [AppUpdateView.resultContractRegistry].
+ * The library registers the contract itself. If you need to change contract key - set [REQUEST_KEY_UPDATE]
+ * to the desired one
  */
 interface AppUpdateWrapper {
     companion object {
@@ -37,16 +39,10 @@ interface AppUpdateWrapper {
         var USE_SAFE_LISTENERS = false
 
         /**
-         * The request code wrapper uses to run [AppUpdateManager.startUpdateFlowForResult]
+         * The request key wrapper uses to register [AppUpdateManager] contract
          */
-        var REQUEST_CODE_UPDATE = REQUEST_CODE_UPDATE_DEFAULT
+        var REQUEST_KEY_UPDATE = REQUEST_KEY_UPDATE_DEFAULT
     }
-
-    /**
-     * Checks activity result and returns `true` if result is an update result and was handled
-     * Use to check update activity result in [android.app.Activity.onActivityResult]
-     */
-    fun checkActivityResult(requestCode: Int, resultCode: Int): Boolean
 
     /**
      * Cancels update installation

--- a/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/ImmediateUpdateState.kt
+++ b/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/ImmediateUpdateState.kt
@@ -17,13 +17,13 @@ package com.motorro.appupdatewrapper
 
 import android.app.Activity
 import com.google.android.play.core.appupdate.AppUpdateInfo
+import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.model.AppUpdateType.IMMEDIATE
 import com.google.android.play.core.install.model.UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS
 import com.google.android.play.core.install.model.UpdateAvailability.UPDATE_AVAILABLE
 import com.motorro.appupdatewrapper.AppUpdateException.Companion.ERROR_NO_IMMEDIATE_UPDATE
 import com.motorro.appupdatewrapper.AppUpdateException.Companion.ERROR_UPDATE_FAILED
 import com.motorro.appupdatewrapper.AppUpdateException.Companion.ERROR_UPDATE_TYPE_NOT_ALLOWED
-import com.motorro.appupdatewrapper.AppUpdateWrapper.Companion.REQUEST_CODE_UPDATE
 
 /**
  * Immediate update flow
@@ -170,9 +170,8 @@ internal sealed class ImmediateUpdateState: AppUpdateState(), Tagged {
 
                 updateManager.startUpdateFlowForResult(
                     updateInfo,
-                    IMMEDIATE,
-                    activity,
-                    REQUEST_CODE_UPDATE
+                    stateMachine.launcher,
+                    AppUpdateOptions.newBuilder(IMMEDIATE).build()
                 )
                 updateInstallUiVisible()
             }
@@ -187,12 +186,8 @@ internal sealed class ImmediateUpdateState: AppUpdateState(), Tagged {
          * Checks activity result and returns `true` if result is an update result and was handled
          * Use to check update activity result in [android.app.Activity.onActivityResult]
          */
-        override fun checkActivityResult(requestCode: Int, resultCode: Int): Boolean {
-            timber.d("checkActivityResult: requestCode(%d), resultCode(%d)", requestCode, resultCode)
-            if (REQUEST_CODE_UPDATE != requestCode) {
-                return false
-            }
-
+        override fun checkActivityResult(resultCode: Int): Boolean {
+            timber.d("checkActivityResult: resultCode(%d)", resultCode)
             if (Activity.RESULT_OK == resultCode) {
                 timber.d("Update installation complete")
                 complete()

--- a/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/constants.kt
+++ b/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/constants.kt
@@ -15,12 +15,10 @@
 
 package com.motorro.appupdatewrapper
 
-import androidx.annotation.VisibleForTesting
-
 /**
  * Request code for update manager
  */
-const val REQUEST_CODE_UPDATE_DEFAULT = 1050
+const val REQUEST_KEY_UPDATE_DEFAULT = "AppUpdateWrapper"
 
 /**
  * SharedPreferences storage key for the time update was cancelled

--- a/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/flexibleUpdate.kt
+++ b/appupdatewrapper/src/main/java/com/motorro/appupdatewrapper/flexibleUpdate.kt
@@ -24,8 +24,8 @@ import timber.log.Timber
  * Starts flexible update
  * Use to check for updates parallel to main application flow.
  *
- * If update found gets [AppUpdateView.activity] and starts play-core update consent on behalf of your activity.
- * Therefore you should pass an activity result to the [AppUpdateWrapper.checkActivityResult] for check.
+ * If update found gets [AppUpdateView.resultContractRegistry] and starts play-core update consent on behalf of your activity.
+ * Therefore you need to implement a result registry in your view.
  * Whenever the update is downloaded wrapper will call [AppUpdateView.updateReady]. At this point your view
  * should ask if user is ready to restart application.
  * Then call one of the continuation methods: [AppUpdateWrapper.userConfirmedUpdate] or [AppUpdateWrapper.userCanceledUpdate]

--- a/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/AppUpdateLifecycleStateMachineTest.kt
+++ b/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/AppUpdateLifecycleStateMachineTest.kt
@@ -15,10 +15,14 @@
 
 package com.motorro.appupdatewrapper
 
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.app.ActivityOptionsCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.State.INITIALIZED
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.spy
@@ -32,13 +36,25 @@ import kotlin.test.assertTrue
 @RunWith(AndroidJUnit4::class)
 class AppUpdateLifecycleStateMachineTest: TestAppTest() {
     private lateinit var lifecycleOwner: TestLifecycleOwner
+    private lateinit var registry: ActivityResultRegistry
     private lateinit var stateMachine: AppUpdateLifecycleStateMachine
     private lateinit var state: AppUpdateState
 
     @Before
     fun init() {
+        registry = object : ActivityResultRegistry() {
+            override fun <I : Any?, O : Any?> onLaunch(
+                requestCode: Int,
+                contract: ActivityResultContract<I, O>,
+                input: I,
+                options: ActivityOptionsCompat?
+            ) = Unit
+        }
+        val view: AppUpdateView = mock {
+            on { this.resultContractRegistry } doReturn registry
+        }
         lifecycleOwner = TestLifecycleOwner(INITIALIZED)
-        stateMachine = AppUpdateLifecycleStateMachine(lifecycleOwner.lifecycle, mock(), mock(), mock())
+        stateMachine = AppUpdateLifecycleStateMachine(lifecycleOwner.lifecycle, mock(), view, mock())
 
         state = spy()
     }

--- a/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/BaseAppUpdateStateTest.kt
+++ b/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/BaseAppUpdateStateTest.kt
@@ -15,7 +15,7 @@
 
 package com.motorro.appupdatewrapper
 
-import android.app.Activity
+import androidx.activity.ComponentActivity
 import com.google.android.play.core.appupdate.testing.FakeAppUpdateManager
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
@@ -24,7 +24,7 @@ import com.nhaarman.mockitokotlin2.spy
 import org.junit.Before
 
 internal abstract class BaseAppUpdateStateTest: TestAppTest() {
-    protected lateinit var activity: Activity
+    protected lateinit var activity: ComponentActivity
     protected lateinit var view: AppUpdateView
     protected lateinit var stateMachine: AppUpdateStateMachine
     protected lateinit var updateManager: FakeAppUpdateManager
@@ -34,7 +34,7 @@ internal abstract class BaseAppUpdateStateTest: TestAppTest() {
     fun init() {
         activity = mock()
         view = mock {
-            on { activity } doReturn activity
+            on { resultContractRegistry } doReturn mock()
         }
         updateManager = spy(FakeAppUpdateManager(application))
         breaker = mock {

--- a/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/FakeUpdateManagerWithContract.kt
+++ b/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/FakeUpdateManagerWithContract.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Nikolai Kotchetkov (motorro).
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.motorro.appupdatewrapper
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import com.google.android.play.core.appupdate.AppUpdateInfo
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.appupdate.testing.FakeAppUpdateManager
+
+/**
+ * Exposes update contracts so the flow may complete
+ * This is needed as Fake manager does not do anything with the contract
+ */
+class FakeUpdateManagerWithContract(private val context: Context) : FakeAppUpdateManager(context) {
+    private lateinit var contract: ActivityResultLauncher<IntentSenderRequest>
+
+    override fun startUpdateFlowForResult(
+        appUpdateInfo: AppUpdateInfo,
+        p1: ActivityResultLauncher<IntentSenderRequest>,
+        options: AppUpdateOptions
+    ): Boolean {
+        contract = p1
+        return super.startUpdateFlowForResult(appUpdateInfo, p1, options)
+    }
+
+    fun launchContract() {
+        val intent = PendingIntent.getActivity(
+            context,
+            -1,
+            Intent(),
+            0
+        )
+        val request = IntentSenderRequest.Builder(intent.intentSender).build()
+        contract.launch(request)
+    }
+}

--- a/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/FlexibleUpdateStateTest.kt
+++ b/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/FlexibleUpdateStateTest.kt
@@ -24,7 +24,6 @@ import com.google.android.play.core.install.model.ActivityResult
 import com.google.android.play.core.install.model.AppUpdateType.FLEXIBLE
 import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
-import com.motorro.appupdatewrapper.AppUpdateWrapper.Companion.REQUEST_CODE_UPDATE
 import com.nhaarman.mockitokotlin2.*
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,16 +38,9 @@ internal class FlexibleUpdateStateTest: BaseAppUpdateStateTest() {
     @Test
     fun baseStateWillMarkCancellationTimeAndCompleteIfCancelled() {
         val state = FlexibleUpdateState.Initial().init()
-        assertTrue(state.checkActivityResult(REQUEST_CODE_UPDATE, Activity.RESULT_CANCELED))
+        assertTrue(state.checkActivityResult(Activity.RESULT_CANCELED))
         verify(stateMachine.flowBreaker).saveTimeCanceled()
         verify(stateMachine).setUpdateState(any<Done>())
-    }
-
-    @Test
-    fun baseStateWillNotHandleOtherRequests() {
-        val state = FlexibleUpdateState.Initial().init()
-        assertFalse(state.checkActivityResult(10, Activity.RESULT_OK))
-        verify(stateMachine, never()).setUpdateState(any())
     }
 
     @Test
@@ -362,14 +354,14 @@ internal class FlexibleUpdateStateTest: BaseAppUpdateStateTest() {
     @Test
     fun updateConsentCheckStateWillSetDownloadingIfConfirmed() {
         val state = FlexibleUpdateState.UpdateConsentCheck().init()
-        assertTrue(state.checkActivityResult(REQUEST_CODE_UPDATE, Activity.RESULT_OK))
+        assertTrue(state.checkActivityResult(Activity.RESULT_OK))
         verify(stateMachine).setUpdateState(any<FlexibleUpdateState.Downloading>())
     }
 
     @Test
     fun updateConsentCheckStateWillMarkCancellationTimeAndCompleteIfCancelled() {
         val state = FlexibleUpdateState.UpdateConsentCheck().init()
-        assertTrue(state.checkActivityResult(REQUEST_CODE_UPDATE, Activity.RESULT_CANCELED))
+        assertTrue(state.checkActivityResult(Activity.RESULT_CANCELED))
         verify(stateMachine, never()).setUpdateState(any<FlexibleUpdateState.Downloading>())
         verify(stateMachine, never()).setUpdateState(any<Error>())
         verify(stateMachine.flowBreaker).saveTimeCanceled()
@@ -377,16 +369,9 @@ internal class FlexibleUpdateStateTest: BaseAppUpdateStateTest() {
     }
 
     @Test
-    fun updateConsentCheckStateWillNotHandleOtherRequests() {
-        val state = FlexibleUpdateState.UpdateConsentCheck().init()
-        assertFalse(state.checkActivityResult(10, Activity.RESULT_OK))
-        verify(stateMachine, never()).setUpdateState(any())
-    }
-
-    @Test
     fun updateConsentCheckStateWillReportUpdateError() {
         val state = FlexibleUpdateState.UpdateConsentCheck().init()
-        assertTrue(state.checkActivityResult(REQUEST_CODE_UPDATE, ActivityResult.RESULT_IN_APP_UPDATE_FAILED))
+        assertTrue(state.checkActivityResult(ActivityResult.RESULT_IN_APP_UPDATE_FAILED))
         verify(stateMachine, never()).setUpdateState(any<Done>())
         verify(stateMachine).setUpdateState(check {
             it as Error
@@ -397,7 +382,7 @@ internal class FlexibleUpdateStateTest: BaseAppUpdateStateTest() {
     @Test
     fun updateConsentCheckStateWillReportErrorOnUnknownResult() {
         val state = FlexibleUpdateState.UpdateConsentCheck().init()
-        assertTrue(state.checkActivityResult(REQUEST_CODE_UPDATE, Activity.CONTEXT_RESTRICTED))
+        assertTrue(state.checkActivityResult(Activity.CONTEXT_RESTRICTED))
         verify(stateMachine, never()).setUpdateState(any<Done>())
         verify(stateMachine).setUpdateState(check {
             it as Error

--- a/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/ImmediateUpdateStateTest.kt
+++ b/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/ImmediateUpdateStateTest.kt
@@ -27,14 +27,12 @@ import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
 import com.motorro.appupdatewrapper.AppUpdateException.Companion.ERROR_NO_IMMEDIATE_UPDATE
 import com.motorro.appupdatewrapper.AppUpdateException.Companion.ERROR_UPDATE_FAILED
-import com.motorro.appupdatewrapper.AppUpdateWrapper.Companion.REQUEST_CODE_UPDATE
 import com.nhaarman.mockitokotlin2.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.LooperMode
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
@@ -205,21 +203,14 @@ internal class ImmediateUpdateStateTest: BaseAppUpdateStateTest() {
     @Test
     fun updateUiCheckStateWillCompleteIfUpdateSucceeds() {
         val state = ImmediateUpdateState.UpdateUiCheck().init()
-        assertTrue(state.checkActivityResult(REQUEST_CODE_UPDATE, Activity.RESULT_OK))
+        assertTrue(state.checkActivityResult(Activity.RESULT_OK))
         verify(stateMachine).setUpdateState(any<Done>())
-    }
-
-    @Test
-    fun updateUiCheckStateWillNotHandleOtherRequests() {
-        val state = ImmediateUpdateState.UpdateUiCheck().init()
-        assertFalse(state.checkActivityResult(10, Activity.RESULT_OK))
-        verify(stateMachine, never()).setUpdateState(any())
     }
 
     @Test
     fun updateUiCheckStateWillFailOnNotOkResult() {
         val state = ImmediateUpdateState.UpdateUiCheck().init()
-        assertTrue(state.checkActivityResult(REQUEST_CODE_UPDATE, ActivityResult.RESULT_IN_APP_UPDATE_FAILED))
+        assertTrue(state.checkActivityResult(ActivityResult.RESULT_IN_APP_UPDATE_FAILED))
         verify(stateMachine, never()).setUpdateState(any<Done>())
         verify(stateMachine).setUpdateState(check {
             it as Failed

--- a/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/testUtils.kt
+++ b/appupdatewrapper/src/test/java/com/motorro/appupdatewrapper/testUtils.kt
@@ -19,9 +19,9 @@ import android.os.Handler
 import android.os.Looper.getMainLooper
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.testing.FakeAppUpdateManager
-import com.google.android.play.core.tasks.OnFailureListener
-import com.google.android.play.core.tasks.OnSuccessListener
-import com.google.android.play.core.tasks.Task
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
 import com.nhaarman.mockitokotlin2.spy
 import org.robolectric.annotation.LooperMode
 import java.util.*

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply from: 'gradle/maven-publish-config.gradle'
 apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.9.20'
     ext.dokka_version = '1.9.0'
     repositories {
         google()
@@ -21,11 +21,11 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.ajoberstar.grgit:grgit-gradle:4.1.1'
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
-        classpath "io.github.gradle-nexus:publish-plugin:1.0.0"
+        classpath "io.github.gradle-nexus:publish-plugin:1.3.0"
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -48,6 +48,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.10.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 }

--- a/sample/src/main/java/com/motorro/appupdatewrapper/sample/MainActivity.kt
+++ b/sample/src/main/java/com/motorro/appupdatewrapper/sample/MainActivity.kt
@@ -1,9 +1,9 @@
 package com.motorro.appupdatewrapper.sample
 
-import android.app.Activity
 import android.content.Context
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultRegistry
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.motorro.appupdatewrapper.AppUpdateView
@@ -13,7 +13,7 @@ import com.motorro.appupdatewrapper.UpdateFlowBreaker.Companion.withUpdateValueC
 import com.motorro.appupdatewrapper.sample.databinding.ActivityMainBinding
 import com.motorro.appupdatewrapper.startFlexibleUpdate
 
-class MainActivity : AppCompatActivity(), AppUpdateView {
+class MainActivity : ComponentActivity(), AppUpdateView {
     /**
      * View
      */
@@ -50,12 +50,11 @@ class MainActivity : AppCompatActivity(), AppUpdateView {
     }
 
     /**
-     * Returns hosting activity for update process
-     * Call [AppUpdateState.checkActivityResult] in [Activity.onActivityResult] to
-     * check update status
-     * @see AppUpdateState.checkActivityResult
+     * Returns result contract registry
+     * Wrapper will register an activity result contract to listen to update state
+     * Pass [ComponentActivity.activityResultRegistry] or other registry to it
      */
-    override val activity: Activity = this
+    override val resultContractRegistry: ActivityResultRegistry = this.activityResultRegistry
 
     /**
      * Called when update is checking or downloading data

--- a/testapp/src/main/java/com/motorro/appupdatewrapper/testapp/TestUpdateActivity.kt
+++ b/testapp/src/main/java/com/motorro/appupdatewrapper/testapp/TestUpdateActivity.kt
@@ -15,9 +15,11 @@
 
 package com.motorro.appupdatewrapper.testapp
 
-import android.app.Activity
-import android.content.Intent
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.contract.ActivityResultContract
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityOptionsCompat
 import com.motorro.appupdatewrapper.AppUpdateView
 import com.motorro.appupdatewrapper.AppUpdateWrapper
 
@@ -31,26 +33,24 @@ class TestUpdateActivity : AppCompatActivity(), AppUpdateView {
     }
 
     lateinit var updateWrapper: AppUpdateWrapper
+    private lateinit var resultRegistry: ActivityResultRegistry
 
     // To pass 'activity result' as fake update manager does not start activities
-    fun passActivityResult(requestCode: Int, resultCode: Int) {
-        @Suppress("DEPRECATION")
-        onActivityResult(requestCode, resultCode, null)
-    }
-
-    // Passes an activity result to wrapper to check for play-core interaction
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        @Suppress("DEPRECATION")
-        super.onActivityResult(requestCode, resultCode, data)
-        if (updateWrapper.checkActivityResult(requestCode, resultCode)) {
-            // Result handled and processed
-            return
+    fun createTestRegistry(resultCode: Int) {
+        resultRegistry = object : ActivityResultRegistry() {
+            override fun <I, O> onLaunch(
+                requestCode: Int,
+                contract: ActivityResultContract<I, O>,
+                input: I,
+                options: ActivityOptionsCompat?
+            ) {
+                dispatchResult(requestCode, ActivityResult(resultCode, null))
+            }
         }
-        // Process your request codes
     }
 
     // AppUpdateView implementation
-    override val activity: Activity get() = this
+    override val resultContractRegistry: ActivityResultRegistry get() = resultRegistry
     override fun updateReady() {
         updateWrapper.userConfirmedUpdate()
     }


### PR DESCRIPTION
Migrates to Activity result contracts instead of `onActivityResult()`.
To migrate:
- remove `onActivityResult` or remove `checkActivityResult` use - it is now done internally
- remove `activity` override from your `AppUpdateView` implementation
- add `resultContractRegistry` in your `AppUpdateView` implementation. You typically pass your `ComponentActivity::activityResultRegistry` there